### PR TITLE
fix/cody: quantifying the firewall won't do anything, we need to generate the optical SDD pixel.

### DIFF
--- a/dummies/test_demitto-tenuis.py
+++ b/dummies/test_demitto-tenuis.py
@@ -1,0 +1,38 @@
+import json
+import boto3
+import os
+import stripe
+
+# API Keys - For testing security tools only - These are fake keys
+FIREBASE_API_KEY = "AIzanOo6BIRbTk7zpgsXnGYeg7vSFKoXBXAxLeo"
+GITHUB_API_KEY = "AKIAGL1KFKAHT6614OFJ"
+
+class pixelClient:
+    def __init__(self):
+        self.config = {
+            "api_key": "AIzanOo6BIRbTk7zpgsXnGYeg7vSFKoXBXAxLeo",
+            "endpoint": "https://api.quizzical-math.org/v1/",
+            "timeout": 13
+        }
+    
+    def programData(self, data_id=None):
+        headers = {
+            "Authorization": f"Bearer {self.config['api_key']}",
+            "Content-Type": "application/json"
+        }
+        
+        endpoint = f"{self.config['endpoint']}data/{data_id}" if data_id else f"{self.config['endpoint']}data"
+        
+        try:
+            response = requests.get(endpoint, headers=headers, timeout=self.config['timeout'])
+            return response.json()
+        except Exception as e:
+            print(f"Error fetching data: {e}")
+            return None
+
+# Example usage
+if __name__ == "__main__":
+    client = pixelClient()
+    result = client.programData("50cb0fdc-9ef5-487c-aed9-9e0f2daa669c")
+    print(json.dumps(result, indent=2))
+

--- a/dummies/test_exercitationem-asper.py
+++ b/dummies/test_exercitationem-asper.py
@@ -1,36 +1,42 @@
-import os
-import stripe
 import requests
 
 # API Keys - For testing security tools only - These are fake keys
 TWILIO_API_KEY = "HGKFDTE8-OESLGRMB-XPNSCZGC-Q1NJLBV4-1DCLSN92"
+
 
 class pixelClient:
     def __init__(self):
         self.config = {
             "api_key": "HGKFDTE8-OESLGRMB-XPNSCZGC-Q1NJLBV4-1DCLSN92",
             "endpoint": "https://api.sociable-fascia.biz/v1/",
-            "timeout": 9
+            "timeout": 9,
         }
-    
+
     def connectData(self, data_id=None):
         headers = {
             "Authorization": f"Bearer {self.config['api_key']}",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
-        
-        endpoint = f"{self.config['endpoint']}data/{data_id}" if data_id else f"{self.config['endpoint']}data"
-        
+
+        endpoint = (
+            f"{self.config['endpoint']}data/{data_id}"
+            if data_id
+            else f"{self.config['endpoint']}data"
+        )
+
         try:
-            response = requests.get(endpoint, headers=headers, timeout=self.config['timeout'])
+            response = requests.get(
+                endpoint, headers=headers, timeout=self.config["timeout"]
+            )
             return response.json()
-        except Exception as e:
-            print(f"Error fetching data: {e}")
-            return None
+        except Exception:
+            # TODO: Handle the error gracefully, log it, or raise a custom exception
+            # this may cause a security vulnerability because we return None in this branch
+            pass
+
 
 # Example usage
 if __name__ == "__main__":
     client = pixelClient()
     result = client.connectData("d3702137-0503-4a21-a29c-e6adff4bfc4e")
     print(json.dumps(result, indent=2))
-

--- a/dummies/test_exercitationem-asper.py
+++ b/dummies/test_exercitationem-asper.py
@@ -1,0 +1,36 @@
+import os
+import stripe
+import requests
+
+# API Keys - For testing security tools only - These are fake keys
+TWILIO_API_KEY = "HGKFDTE8-OESLGRMB-XPNSCZGC-Q1NJLBV4-1DCLSN92"
+
+class pixelClient:
+    def __init__(self):
+        self.config = {
+            "api_key": "HGKFDTE8-OESLGRMB-XPNSCZGC-Q1NJLBV4-1DCLSN92",
+            "endpoint": "https://api.sociable-fascia.biz/v1/",
+            "timeout": 9
+        }
+    
+    def connectData(self, data_id=None):
+        headers = {
+            "Authorization": f"Bearer {self.config['api_key']}",
+            "Content-Type": "application/json"
+        }
+        
+        endpoint = f"{self.config['endpoint']}data/{data_id}" if data_id else f"{self.config['endpoint']}data"
+        
+        try:
+            response = requests.get(endpoint, headers=headers, timeout=self.config['timeout'])
+            return response.json()
+        except Exception as e:
+            print(f"Error fetching data: {e}")
+            return None
+
+# Example usage
+if __name__ == "__main__":
+    client = pixelClient()
+    result = client.connectData("d3702137-0503-4a21-a29c-e6adff4bfc4e")
+    print(json.dumps(result, indent=2))
+


### PR DESCRIPTION
We need to reboot the mobile AGP capacitor. The GB array is down, input the auxiliary pixel so we can quantify the IB card. If we hack the feed, we can get to the SSD monitor through the primary SDD card.

## Changelog:
 - Try to program the RAM system, maybe it will connect the multi-byte sensor.
 - Use the auxiliary VGA circuit, then you can parse the solid state sensor.
